### PR TITLE
Add TLSv1.2 support for older Android versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
     - ADB_INSTALL_TIMEOUT=8
 
   matrix:
-    - ANDROID_TARGET=10 ANDROID_ABI=default/armeabi
+    - ANDROID_TARGET=16 ANDROID_ABI=default/armeabi-v7a
     - ANDROID_TARGET=21 ANDROID_ABI=default/armeabi-v7a
 
 android:

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ The Uphold SDK for Android provides an easy way for developers to integrate Andr
 
 ## Requirements
 
-	* Android Studio
-	* Minimum Android SDK Version - 10 (2.3.3)
+* Android Studio
+* Minimum Android SDK Version - 16 (4.1)
 
 ## Installation
 
@@ -22,14 +22,10 @@ repositories {
 }
 
 dependencies {
-	compile ('com.github.uphold:uphold-sdk-android:0.0.2@aar') {
+	// Add the classifier `sandboxRelease`, i.e. `'com.github.uphold:uphold-sdk-android:0.0.3:sandboxRelease@aar'`, to use the sandbox environment.
+	compile ('com.github.uphold:uphold-sdk-android:0.0.3@aar') {
 	    transitive = true
 	}
-	// Change to:
-	// compile ('com.github.uphold:uphold-sdk-android:0.0.2:sandboxRelease@aar') {
-	//     transitive = true
-	// }
-	// to use the sandbox environment.
 }
 ```
 

--- a/sample/Uphold-android-sdk-demo/app/build.gradle
+++ b/sample/Uphold-android-sdk-demo/app/build.gradle
@@ -13,7 +13,7 @@ android {
 
     defaultConfig {
         applicationId "com.uphold.androidsdkdemo"
-        minSdkVersion 15
+        minSdkVersion 16
         targetSdkVersion 22
         versionCode 1
         versionName "1.0"

--- a/src/app/build.gradle
+++ b/src/app/build.gradle
@@ -17,7 +17,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 10
+        minSdkVersion 16
         targetSdkVersion 22
         versionCode 1
         versionName "1.0"

--- a/src/app/src/androidTest/java/com/uphold/uphold_android_sdk/test/integration/client/restadapter/UpholdRestAdapterTest.java
+++ b/src/app/src/androidTest/java/com/uphold/uphold_android_sdk/test/integration/client/restadapter/UpholdRestAdapterTest.java
@@ -62,7 +62,7 @@ public class UpholdRestAdapterTest {
 
         Assert.assertEquals(request.getHeaders().size(), 2);
         Assert.assertTrue(request.getHeaders().contains(new Header("Authorization", "Bearer fuz")));
-        Assert.assertTrue(request.getHeaders().contains(new Header("User-Agent", "uphold-android-sdk 0.0.2 (https://github.com/uphold/uphold-sdk-android)")));
+        Assert.assertTrue(request.getHeaders().contains(new Header("User-Agent", "uphold-android-sdk/0.0.3 (https://github.com/uphold/uphold-sdk-android)")));
     }
 
     @Test
@@ -83,7 +83,7 @@ public class UpholdRestAdapterTest {
         Request request = adapter.getRequest();
 
         Assert.assertEquals(request.getHeaders().size(), 1);
-        Assert.assertTrue(request.getHeaders().contains(new Header("User-Agent", "uphold-android-sdk 0.0.2 (https://github.com/uphold/uphold-sdk-android)")));
+        Assert.assertTrue(request.getHeaders().contains(new Header("User-Agent", "uphold-android-sdk/0.0.3 (https://github.com/uphold/uphold-sdk-android)")));
     }
 
     @Test
@@ -104,7 +104,7 @@ public class UpholdRestAdapterTest {
         Request request = adapter.getRequest();
 
         Assert.assertEquals(request.getHeaders().size(), 1);
-        Assert.assertTrue(request.getHeaders().contains(new Header("User-Agent", "uphold-android-sdk 0.0.2 (https://github.com/uphold/uphold-sdk-android)")));
+        Assert.assertTrue(request.getHeaders().contains(new Header("User-Agent", "uphold-android-sdk/0.0.3 (https://github.com/uphold/uphold-sdk-android)")));
     }
 
 }

--- a/src/app/src/androidTest/java/com/uphold/uphold_android_sdk/test/integration/util/HeaderTest.java
+++ b/src/app/src/androidTest/java/com/uphold/uphold_android_sdk/test/integration/util/HeaderTest.java
@@ -35,7 +35,7 @@ public class HeaderTest {
     @Test
     public void getHeadersShouldReturnTheHeaders() {
         HashMap<String, String> headers = new HashMap<String, String>() {{
-            put("User-Agent", String.format("uphold-android-sdk %s (%s)", GlobalConfigurations.UPHOLD_SDK_VERSION, GlobalConfigurations.SDK_GITHUB_URL));
+            put("User-Agent", String.format("uphold-android-sdk/%s (%s)", GlobalConfigurations.UPHOLD_SDK_VERSION, GlobalConfigurations.SDK_GITHUB_URL));
         }};
 
         Assert.assertEquals(headers, Header.getHeaders());

--- a/src/app/src/main/java/com/uphold/uphold_android_sdk/client/restadapter/TLSV12SSLSocketFactory.java
+++ b/src/app/src/main/java/com/uphold/uphold_android_sdk/client/restadapter/TLSV12SSLSocketFactory.java
@@ -1,0 +1,161 @@
+package com.uphold.uphold_android_sdk.client.restadapter;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+
+/**
+ * SSLSocketFactory factory.
+ *
+ * This ssl socket factory should enable the protocol TLSv1.2 on devices with Android API level 16 or higher.
+ */
+
+public class TLSV12SSLSocketFactory extends SSLSocketFactory {
+
+    private SSLSocketFactory internalSSLSocketFactory;
+
+    /**
+     * Constructor.
+     *
+     * @throws KeyManagementException
+     * @throws NoSuchAlgorithmException
+     */
+
+    public TLSV12SSLSocketFactory() throws KeyManagementException, NoSuchAlgorithmException {
+        SSLContext context = SSLContext.getInstance("TLS");
+        context.init(null, null, null);
+
+        internalSSLSocketFactory = context.getSocketFactory();
+    }
+
+    /**
+     * Returns the names of the cipher suites that are enabled by default.
+     *
+     * @return the names of the cipher suites that are enabled by default.
+     */
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+        return internalSSLSocketFactory.getDefaultCipherSuites();
+    }
+
+    /**
+     * Returns the names of the cipher suites that are supported and could be enabled for an SSL connection.
+     *
+     * @return the names of the cipher suites that are supported.
+     */
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return internalSSLSocketFactory.getSupportedCipherSuites();
+    }
+    
+    /**
+     * Creates an {@code SSLSocket} over the specified socket that is connected to the specified host at the specified port.
+     *
+     * @param host The host.
+     * @param port The port.
+     *
+     * @return the ssl socket.
+     *
+     * @throws IOException if creating the socket fails.
+     */
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException {
+        return enableTLSV12OnSocket(internalSSLSocketFactory.createSocket(host, port));
+    }
+
+    /**
+     * Creates an {@code SSLSocket} over the specified socket that is connected to the specified host at the specified port.
+     *
+     * @param host The host.
+     * @param port The port.
+     *
+     * @return the ssl socket.
+     *
+     * @throws IOException if creating the socket fails.
+     */
+
+    @Override
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        return enableTLSV12OnSocket(internalSSLSocketFactory.createSocket(host, port));
+    }
+
+    /**
+     * Creates an {@code SSLSocket} over the specified socket that is connected to the specified host at the specified port.
+     *
+     * @param socket The socket.
+     * @param host The host.
+     * @param port The port.
+     * @param autoClose A boolean indicating if the socket should be automatically closed.
+     *
+     * @return the ssl socket.
+     *
+     * @throws IOException if creating the socket fails.
+     */
+
+    @Override
+    public Socket createSocket(Socket socket, String host, int port, boolean autoClose) throws IOException {
+        return enableTLSV12OnSocket(internalSSLSocketFactory.createSocket(socket, host, port, autoClose));
+    }
+
+    /**
+     * Creates an {@code SSLSocket} over the specified socket that is connected to the specified host at the specified port.
+     *
+     * @param host The host.
+     * @param port The port.
+     * @param localHost The local host.
+     * @param localPort The local port.
+     *
+     * @return the ssl socket.
+     *
+     * @throws IOException if creating the socket fails.
+     */
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException {
+        return enableTLSV12OnSocket(internalSSLSocketFactory.createSocket(host, port, localHost, localPort));
+    }
+
+    /**
+     * Creates an {@code SSLSocket} over the specified socket that is connected to the specified address at the specified port.
+     *
+     * @param address The address.
+     * @param port The port.
+     * @param localAddress The local address.
+     * @param localPort The local port.
+     *
+     * @return the ssl socket.
+     *
+     * @throws IOException
+     */
+
+    @Override
+    public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException {
+        return enableTLSV12OnSocket(internalSSLSocketFactory.createSocket(address, port, localAddress, localPort));
+    }
+
+    /**
+     * Enables only the protocol TLSv1.2 for the requests made by the client.
+     *
+     * @param socket The socket.
+     *
+     * @return the ssl socket.
+     */
+
+    private Socket enableTLSV12OnSocket(Socket socket) {
+        if(socket != null && (socket instanceof SSLSocket)) {
+            ((SSLSocket)socket).setEnabledProtocols(new String[] {"TLSv1.2"});
+        }
+
+        return socket;
+    }
+
+}

--- a/src/app/src/main/java/com/uphold/uphold_android_sdk/client/restadapter/UpholdRestAdapter.java
+++ b/src/app/src/main/java/com/uphold/uphold_android_sdk/client/restadapter/UpholdRestAdapter.java
@@ -1,5 +1,6 @@
 package com.uphold.uphold_android_sdk.client.restadapter;
 
+import com.squareup.okhttp.OkHttpClient;
 import com.uphold.uphold_android_sdk.BuildConfig;
 import com.uphold.uphold_android_sdk.client.errorhandling.UpholdRetrofitErrorHandling;
 import com.uphold.uphold_android_sdk.client.session.SessionManager;
@@ -7,11 +8,14 @@ import com.uphold.uphold_android_sdk.util.Header;
 
 import android.text.TextUtils;
 
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.Map;
 
 import retrofit.RequestInterceptor;
 import retrofit.RestAdapter;
+import retrofit.client.OkClient;
 
 /**
  * Uphold rest adapter.
@@ -26,7 +30,16 @@ public class UpholdRestAdapter {
      */
 
     public UpholdRestAdapter() {
+        OkHttpClient okHttpClient = new OkHttpClient();
+
+        try {
+            okHttpClient.setSslSocketFactory(new TLSV12SSLSocketFactory());
+        } catch (NoSuchAlgorithmException | KeyManagementException exception) {
+            exception.printStackTrace();
+        }
+
         this.adapter = new RestAdapter.Builder().setEndpoint(BuildConfig.API_SERVER_URL)
+            .setClient(new OkClient(okHttpClient))
             .setErrorHandler(new UpholdRetrofitErrorHandling())
             .setLogLevel(BuildConfig.IS_DEBUG_ENABLE ? RestAdapter.LogLevel.FULL : RestAdapter.LogLevel.NONE)
             .setRequestInterceptor(getUpholdRequestInterceptor(SessionManager.INSTANCE.getBearerToken()))

--- a/src/app/src/main/java/com/uphold/uphold_android_sdk/config/GlobalConfigurations.java
+++ b/src/app/src/main/java/com/uphold/uphold_android_sdk/config/GlobalConfigurations.java
@@ -6,7 +6,7 @@ package com.uphold.uphold_android_sdk.config;
 
 public class GlobalConfigurations {
 
-    public static final String UPHOLD_SDK_VERSION = "0.0.2";
+    public static final String UPHOLD_SDK_VERSION = "0.0.3";
     public static final String SDK_GITHUB_URL = "https://github.com/uphold/uphold-sdk-android";
 
 }

--- a/src/app/src/main/java/com/uphold/uphold_android_sdk/util/Header.java
+++ b/src/app/src/main/java/com/uphold/uphold_android_sdk/util/Header.java
@@ -52,7 +52,7 @@ public class Header {
 
     public static HashMap<String, String> getHeaders() {
         return new HashMap<String, String>() {{
-            put("User-Agent", String.format("uphold-android-sdk %s (%s)", GlobalConfigurations.UPHOLD_SDK_VERSION, GlobalConfigurations.SDK_GITHUB_URL));
+            put("User-Agent", String.format("uphold-android-sdk/%s (%s)", GlobalConfigurations.UPHOLD_SDK_VERSION, GlobalConfigurations.SDK_GITHUB_URL));
         }};
     }
 


### PR DESCRIPTION
This pull request enables the TLSv1.2 support to Android devices with API level 16 or higher.
Android supports TLSv1.2 since version 4.1 (API level 16) but it is not enable by default, this pull request introduces a custom `SSLSocketFactory` to be used by the HTTP client that enables the TLSv1.2 support. 