### PR TITLE
Add network field to transaction model

### DIFF
--- a/src/app/src/androidTest/java/com/uphold/uphold_android_sdk/test/integration/model/CardTest.java
+++ b/src/app/src/androidTest/java/com/uphold/uphold_android_sdk/test/integration/model/CardTest.java
@@ -38,6 +38,7 @@ public class CardTest {
             "\"id\": \"foobar\"," +
             "\"type\": \"transfer\"," +
             "\"message\": \"foobar\"," +
+            "\"network\": \"qux\"," +
             "\"status\": \"pending\"," +
             "\"RefundedById\": \"foobiz\"," +
             "\"createdAt\": \"2014-08-27T00:01:11.616Z\"," +
@@ -120,6 +121,7 @@ public class CardTest {
         Assert.assertEquals(transaction.getId(), "foobar");
         Assert.assertEquals(transaction.getType(), "transfer");
         Assert.assertEquals(transaction.getMessage(), "foobar");
+        Assert.assertEquals(transaction.getNetwork(), "qux");
         Assert.assertEquals(transaction.getStatus(), "pending");
         Assert.assertEquals(transaction.getRefundedById(), "foobiz");
         Assert.assertEquals(transaction.getCreatedAt(), "2014-08-27T00:01:11.616Z");

--- a/src/app/src/androidTest/java/com/uphold/uphold_android_sdk/test/util/Fixtures.java
+++ b/src/app/src/androidTest/java/com/uphold/uphold_android_sdk/test/util/Fixtures.java
@@ -158,6 +158,7 @@ public class Fixtures {
             put("transactionCreatedAt", faker.lorem().fixedString(24));
             put("transactionId", faker.lorem().fixedString(24));
             put("transactionMessage", faker.lorem().fixedString(24));
+            put("transactionNetwork", faker.lorem().fixedString(24));
             put("transactionRefundedById", faker.lorem().fixedString(24));
             put("transactionRefunds", faker.lorem().fixedString(24));
             put("transactionStatus", faker.lorem().fixedString(24));
@@ -187,7 +188,7 @@ public class Fixtures {
         Origin origin = new Origin(fakerFields.get("originAccountId"), fakerFields.get("originCardId"), fakerFields.get("originAccountType"), fakerFields.get("originAmount"), fakerFields.get("originBase"), fakerFields.get("originCommission"), fakerFields.get("originCurrency"), fakerFields.get("originDescription"), fakerFields.get("originFee"), fakerFields.get("originRate"), sources, fakerFields.get("originType"), fakerFields.get("originUsername"));
         Parameters parameters = new Parameters(fakerFields.get("parametersCurrency"), fakerFields.get("parametersMargin"), fakerFields.get("parametersPair"), fakerFields.get("parametersProgress"), fakerFields.get("parametersRate"), fakerFields.get("parametersRefunds"), Integer.parseInt(fakerFields.get("parametersTtl")), fakerFields.get("parametersTxid"), fakerFields.get("parametersType"));
 
-        return new Transaction(fakerFields.get("transactionId"), fakerFields.get("transactionCreatedAt"), denomination, destination, fees, fakerFields.get("transactionMessage"), normalized, origin, parameters, fakerFields.get("transactionRefundedById"), fakerFields.get("transactionStatus"), fakerFields.get("transactionType"));
+        return new Transaction(fakerFields.get("transactionId"), fakerFields.get("transactionCreatedAt"), denomination, destination, fees, fakerFields.get("transactionMessage"), fakerFields.get("transactionNetwork"), normalized, origin, parameters, fakerFields.get("transactionRefundedById"), fakerFields.get("transactionStatus"), fakerFields.get("transactionType"));
     }
 
     public static TransactionRequest loadTransactionRequest(){

--- a/src/app/src/main/java/com/uphold/uphold_android_sdk/model/Transaction.java
+++ b/src/app/src/main/java/com/uphold/uphold_android_sdk/model/Transaction.java
@@ -29,6 +29,7 @@ public class Transaction extends BaseModel implements Serializable {
     private final Destination destination;
     private final List<Fee> fees;
     private final String message;
+    private final String network;
     private final List<Normalized> normalized;
     private final Origin origin;
     private final Parameters params;
@@ -45,6 +46,7 @@ public class Transaction extends BaseModel implements Serializable {
      * @param destination The recipient of the funds.
      * @param fees The transaction fees.
      * @param message A message or note provided by the user at the time the transaction was initiated, with the intent of communicating additional information and context about the nature/purpose of the transaction.
+     * @param network The network of the transaction.
      * @param normalized The transaction details normalized.
      * @param origin The sender of the funds.
      * @param params Other parameters of this transaction.
@@ -53,13 +55,14 @@ public class Transaction extends BaseModel implements Serializable {
      * @param type The nature of the transaction.
      */
 
-    public Transaction(String id, String createdAt, Denomination denomination, Destination destination, List<Fee> fees, String message, List<Normalized> normalized, Origin origin, Parameters params, String refundedById, String status, String type) {
+    public Transaction(String id, String createdAt, Denomination denomination, Destination destination, List<Fee> fees, String message, String network, List<Normalized> normalized, Origin origin, Parameters params, String refundedById, String status, String type) {
         this.id = id;
         this.createdAt = createdAt;
         this.denomination = denomination;
         this.destination = destination;
         this.fees = fees;
         this.message = message;
+        this.network = network;
         this.normalized = normalized;
         this.origin = origin;
         this.params = params;
@@ -202,6 +205,16 @@ public class Transaction extends BaseModel implements Serializable {
 
     public String getMessage() {
         return message;
+    }
+
+    /**
+     * Gets the network of the transaction.
+     *
+     * @return network of the transaction.
+     */
+
+    public String getNetwork() {
+        return network;
     }
 
     /**

--- a/src/app/src/test/java/com/uphold/uphold_android_sdk/test/unit/model/TransactionTest.java
+++ b/src/app/src/test/java/com/uphold/uphold_android_sdk/test/unit/model/TransactionTest.java
@@ -38,7 +38,7 @@ public class TransactionTest {
         Parameters parameters = new Parameters("foobar", "foobiz", "foobuz", "fizbiz", "fuz", "fiz", 1, "foo", "bar");
         Normalized normalized = new Normalized("foo", "bar", "fiz", "biz", "fixbiz");
         Source source = new Source("FUZBUZ", "FIZBIZ");
-        Transaction transaction = new Transaction("foobar", "foobiz", denomination, destination, fees, "fuzbuz", normalizeds, origin, parameters, "fizbiz", "foobuz", "foo");
+        Transaction transaction = new Transaction("foobar", "foobiz", denomination, destination, fees, "fuzbuz", "qux", normalizeds, origin, parameters, "fizbiz", "foobuz", "foo");
 
         fees.add(fee);
         normalizeds.add(normalized);
@@ -71,6 +71,7 @@ public class TransactionTest {
         Assert.assertEquals(transaction.getFees().get(0).getType(), deserializedTransaction.getFees().get(0).getType());
         Assert.assertEquals(transaction.getId(), deserializedTransaction.getId());
         Assert.assertEquals(transaction.getMessage(), deserializedTransaction.getMessage());
+        Assert.assertEquals(transaction.getNetwork(), deserializedTransaction.getNetwork());
         Assert.assertEquals(transaction.getNormalized().size(), 1);
         Assert.assertEquals(transaction.getNormalized().get(0).getAmount(), deserializedTransaction.getNormalized().get(0).getAmount());
         Assert.assertEquals(transaction.getNormalized().get(0).getCommission(), deserializedTransaction.getNormalized().get(0).getCommission());


### PR DESCRIPTION
This PR adds the field `network` to the transaction model.