### PR TITLE
Update BaseModel rest adapter to be protected

### DIFF
--- a/src/app/src/main/java/com/uphold/uphold_android_sdk/model/BaseModel.java
+++ b/src/app/src/main/java/com/uphold/uphold_android_sdk/model/BaseModel.java
@@ -10,7 +10,7 @@ import java.io.Serializable;
 
 public class BaseModel implements Serializable {
 
-    private transient UpholdRestAdapter upholdRestAdapter;
+    protected transient UpholdRestAdapter upholdRestAdapter;
 
     /**
      * Constructor.


### PR DESCRIPTION
This PR updates the `BaseModel` `upholdRestAdapter` field to be `protected` which will allow to override the `getUpholdRestAdapter` method.