### PR TITLE
Update OkHttpClient version

### DIFF
--- a/src/app/build.gradle
+++ b/src/app/build.gradle
@@ -73,9 +73,8 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     implementation 'com.darylteo:rxjava-promises-java:1.2.1'
-    implementation 'com.squareup.okhttp:okhttp-urlconnection:2.7.5'
-    implementation 'com.squareup.okhttp:okhttp:2.7.5'
-    implementation 'com.squareup.retrofit:retrofit:1.9.0'
+    implementation 'com.jakewharton.retrofit:retrofit1-okhttp3-client:1.1.0'
+    implementation 'com.squareup.okhttp3:okhttp:3.9.1'
 
     androidTestImplementation 'com.android.support.test:testing-support-lib:0.1'
     androidTestImplementation 'org.hamcrest:hamcrest-library:1.3'

--- a/src/app/src/test/java/com/uphold/uphold_android_sdk/test/unit/client/UpholdClientTest.java
+++ b/src/app/src/test/java/com/uphold/uphold_android_sdk/test/unit/client/UpholdClientTest.java
@@ -1,18 +1,20 @@
 package com.uphold.uphold_android_sdk.test.unit.client;
 
+import android.net.Uri;
+import android.test.mock.MockContext;
+import android.text.TextUtils;
+
 import com.uphold.uphold_android_sdk.BuildConfig;
 import com.uphold.uphold_android_sdk.client.UpholdClient;
 import com.uphold.uphold_android_sdk.test.unit.util.MockSharedPreferencesContext;
 import com.uphold.uphold_android_sdk.util.Header;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-
-import android.net.Uri;
-import android.test.mock.MockContext;
-import android.text.TextUtils;
 
 import java.util.ArrayList;
 
@@ -22,6 +24,7 @@ import java.util.ArrayList;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Uri.class, TextUtils.class})
+@PowerMockIgnore("javax.net.ssl.*")
 public class UpholdClientTest {
 
     @Test


### PR DESCRIPTION
This PR updates the `OkHttpClient` dependency to version 3.9.1.