### PR TITLE
Add Node model to Origin/Destination of a transaction

### DIFF
--- a/src/app/src/androidTest/java/com/uphold/uphold_android_sdk/test/integration/model/TransactionTest.java
+++ b/src/app/src/androidTest/java/com/uphold/uphold_android_sdk/test/integration/model/TransactionTest.java
@@ -538,6 +538,9 @@ public class TransactionTest {
             put("destinationMerchantName", "buz");
             put("destinationMerchantState", "fiz");
             put("destinationMerchantZipCode", "biz");
+            put("destinationNodeBrand", "foz");
+            put("destinationNodeId", "fez");
+            put("destinationNodeType", "faz");
             put("destinationRate", "buz");
             put("destinationType", "fuzbiz");
             put("destinationUsername", "fizbuz");
@@ -555,6 +558,9 @@ public class TransactionTest {
         Assert.assertEquals(transaction.getDestination().getMerchant().getName(), "buz");
         Assert.assertEquals(transaction.getDestination().getMerchant().getState(), "fiz");
         Assert.assertEquals(transaction.getDestination().getMerchant().getZipCode(), "biz");
+        Assert.assertEquals(transaction.getDestination().getNode().getBrand(), "foz");
+        Assert.assertEquals(transaction.getDestination().getNode().getId(), "fez");
+        Assert.assertEquals(transaction.getDestination().getNode().getType(), "faz");
         Assert.assertEquals(transaction.getDestination().getRate(), "buz");
         Assert.assertEquals(transaction.getDestination().getType(), "fuzbiz");
         Assert.assertEquals(transaction.getDestination().getUsername(), "fizbuz");
@@ -601,6 +607,9 @@ public class TransactionTest {
             put("originMerchantName", "buz");
             put("originMerchantState", "fiz");
             put("originMerchantZipCode", "biz");
+            put("originNodeBrand", "foz");
+            put("originNodeId", "fez");
+            put("originNodeType", "faz");
             put("originRate", "buz");
             put("originSourcesAmount", "fuzbiz,fizbuz");
             put("originSourcesId", "foo,bar");
@@ -620,6 +629,9 @@ public class TransactionTest {
         Assert.assertEquals(transaction.getOrigin().getMerchant().getName(), "buz");
         Assert.assertEquals(transaction.getOrigin().getMerchant().getState(), "fiz");
         Assert.assertEquals(transaction.getOrigin().getMerchant().getZipCode(), "biz");
+        Assert.assertEquals(transaction.getOrigin().getNode().getBrand(), "foz");
+        Assert.assertEquals(transaction.getOrigin().getNode().getId(), "fez");
+        Assert.assertEquals(transaction.getOrigin().getNode().getType(), "faz");
         Assert.assertEquals(transaction.getOrigin().getRate(), "buz");
         Assert.assertEquals(transaction.getOrigin().getSources().size(), 2);
         Assert.assertEquals(transaction.getOrigin().getSources().get(0).getAmount(), "fuzbiz");

--- a/src/app/src/androidTest/java/com/uphold/uphold_android_sdk/test/util/Fixtures.java
+++ b/src/app/src/androidTest/java/com/uphold/uphold_android_sdk/test/util/Fixtures.java
@@ -10,6 +10,7 @@ import com.uphold.uphold_android_sdk.model.transaction.Denomination;
 import com.uphold.uphold_android_sdk.model.transaction.Destination;
 import com.uphold.uphold_android_sdk.model.transaction.Fee;
 import com.uphold.uphold_android_sdk.model.transaction.Merchant;
+import com.uphold.uphold_android_sdk.model.transaction.Node;
 import com.uphold.uphold_android_sdk.model.transaction.Origin;
 import com.uphold.uphold_android_sdk.model.transaction.Parameters;
 import com.uphold.uphold_android_sdk.model.transaction.Source;
@@ -173,6 +174,9 @@ public class Fixtures {
             put("destinationMerchantName", faker.name().fullName());
             put("destinationMerchantState", faker.address().stateAbbr());
             put("destinationMerchantZipCode", faker.address().zipCode());
+            put("destinationNodeBrand", faker.lorem().fixedString(5));
+            put("destinationNodeId", faker.lorem().fixedString(20));
+            put("destinationNodeType", faker.lorem().fixedString(5));
             put("destinationRate", faker.lorem().fixedString(3));
             put("destinationType", faker.lorem().fixedString(6));
             put("destinationUsername", faker.lorem().fixedString(10));
@@ -200,6 +204,9 @@ public class Fixtures {
             put("originMerchantName", faker.name().fullName());
             put("originMerchantState", faker.address().stateAbbr());
             put("originMerchantZipCode", faker.address().zipCode());
+            put("originNodeBrand", faker.lorem().fixedString(5));
+            put("originNodeId", faker.lorem().fixedString(20));
+            put("originNodeType", faker.lorem().fixedString(5));
             put("originRate", faker.numerify("123456789"));
             put("originSourcesAmount", String.format("%s,%s,%s", faker.numerify("123456789"), faker.numerify("123456789"), faker.numerify("123456789")));
             put("originSourcesId", String.format("%s,%s,%s", faker.lorem().fixedString(24), faker.lorem().fixedString(24), faker.lorem().fixedString(24)));
@@ -228,8 +235,12 @@ public class Fixtures {
         }
 
         Denomination denomination = new Denomination(fakerFields.get("denominationAmount"), fakerFields.get("denominationCurrency"), fakerFields.get("denominationPair"), fakerFields.get("denominationRate"));
-        Merchant destinationMerchant = new Merchant(fakerFields.get("destinationMerchantCity"), fakerFields.get("destinationMerchantCountry"), fakerFields.get("destinationMerchantName"), fakerFields.get("destinationMerchantState"), fakerFields.get("destinationMerchantZipCode"));
-        Destination destination = new Destination(fakerFields.get("destinationAccountId"), fakerFields.get("destinationCardId"), fakerFields.get("destinationAccountType"), fakerFields.get("destinationAmount"), fakerFields.get("destinationBase"), fakerFields.get("destinationCommission"), fakerFields.get("destinationCurrency"), fakerFields.get("destinationDescription"), fakerFields.get("destinationFee"), destinationMerchant,fakerFields.get("destinationRate"), fakerFields.get("destinationType"), fakerFields.get("destinationUsername"));
+        Merchant destinationMerchant = new Merchant(fakerFields.get("destinationMerchantCity"), fakerFields.get("destinationMerchantCountry"), fakerFields.get("destinationMerchantName"), fakerFields.get("destinationMerchantState"),
+            fakerFields.get("destinationMerchantZipCode"));
+        Node destinationNode = new Node(fakerFields.get("destinationNodeBrand"), fakerFields.get("destinationNodeId"), fakerFields.get("destinationNodeType"));
+        Destination destination = new Destination(fakerFields.get("destinationAccountId"), fakerFields.get("destinationCardId"), fakerFields.get("destinationAccountType"), fakerFields.get("destinationAmount"), fakerFields.get("destinationBase"),
+            fakerFields.get("destinationCommission"), fakerFields.get("destinationCurrency"), fakerFields.get("destinationDescription"), fakerFields.get("destinationFee"), destinationMerchant, destinationNode, fakerFields.get("destinationRate"),
+            fakerFields.get("destinationType"), fakerFields.get("destinationUsername"));
         ArrayList<Fee> fees = new ArrayList<Fee>() {{
             add(new Fee(fakerFields.get("feeAmount"), fakerFields.get("feeCurrency"), fakerFields.get("feePercentage"), fakerFields.get("feeTarget"), fakerFields.get("feeType")));
         }};
@@ -245,8 +256,11 @@ public class Fixtures {
             add(new com.uphold.uphold_android_sdk.model.transaction.Normalized(fakerFields.get("normalizedAmount"), fakerFields.get("normalizedCommission"), fakerFields.get("normalizedCurrency"), fakerFields.get("normalizedFee"), fakerFields.get("normalizedRate")));
         }};
         Merchant originMerchant = new Merchant(fakerFields.get("originMerchantCity"), fakerFields.get("originMerchantCountry"), fakerFields.get("originMerchantName"), fakerFields.get("originMerchantState"), fakerFields.get("originMerchantZipCode"));
-        Origin origin = new Origin(fakerFields.get("originAccountId"), fakerFields.get("originCardId"), fakerFields.get("originAccountType"), fakerFields.get("originAmount"), fakerFields.get("originBase"), fakerFields.get("originCommission"), fakerFields.get("originCurrency"), fakerFields.get("originDescription"), fakerFields.get("originFee"), originMerchant, fakerFields.get("originRate"), sources, fakerFields.get("originType"), fakerFields.get("originUsername"));
-        Parameters parameters = new Parameters(fakerFields.get("parametersCurrency"), fakerFields.get("parametersMargin"), fakerFields.get("parametersPair"), fakerFields.get("parametersProgress"), fakerFields.get("parametersRate"), fakerFields.get("parametersRefunds"), Integer.parseInt(fakerFields.get("parametersTtl")), fakerFields.get("parametersTxid"), fakerFields.get("parametersType"));
+        Node originNode = new Node(fakerFields.get("originNodeBrand"), fakerFields.get("originNodeId"), fakerFields.get("originNodeType"));
+        Origin origin = new Origin(fakerFields.get("originAccountId"), fakerFields.get("originCardId"), fakerFields.get("originAccountType"), fakerFields.get("originAmount"), fakerFields.get("originBase"), fakerFields.get("originCommission"),
+            fakerFields.get("originCurrency"), fakerFields.get("originDescription"), fakerFields.get("originFee"), originMerchant, originNode, fakerFields.get("originRate"), sources, fakerFields.get("originType"), fakerFields.get("originUsername"));
+        Parameters parameters = new Parameters(fakerFields.get("parametersCurrency"), fakerFields.get("parametersMargin"), fakerFields.get("parametersPair"), fakerFields.get("parametersProgress"), fakerFields.get("parametersRate"),
+            fakerFields.get("parametersRefunds"), Integer.parseInt(fakerFields.get("parametersTtl")), fakerFields.get("parametersTxid"), fakerFields.get("parametersType"));
 
         return new Transaction(fakerFields.get("transactionId"), fakerFields.get("transactionCreatedAt"), denomination, destination, fees, fakerFields.get("transactionMessage"), fakerFields.get("transactionNetwork"), normalized, origin, parameters, fakerFields.get("transactionRefundedById"), fakerFields.get("transactionStatus"), fakerFields.get("transactionType"));
     }

--- a/src/app/src/main/java/com/uphold/uphold_android_sdk/model/transaction/Destination.java
+++ b/src/app/src/main/java/com/uphold/uphold_android_sdk/model/transaction/Destination.java
@@ -18,6 +18,7 @@ public class Destination implements Serializable {
     private final String description;
     private final String fee;
     private final Merchant merchant;
+    private final Node node;
     private final String rate;
     private final String type;
     private final String username;
@@ -35,12 +36,13 @@ public class Destination implements Serializable {
      * @param description The description from the destination of the transaction.
      * @param fee The fee from the destination of the transaction.
      * @param merchant The merchant from the destination of the transaction.
+     * @param node The node from the destination of the transaction.
      * @param rate The rate from the destination of the transaction.
      * @param type The type from the destination of the transaction.
      * @param username The username from the destination of the transaction.
      */
 
-    public Destination(String AccountId, String cardId, String accountType, String amount, String base, String commission, String currency, String description, String fee, Merchant merchant, String rate, String type, String username) {
+    public Destination(String AccountId, String cardId, String accountType, String amount, String base, String commission, String currency, String description, String fee, Merchant merchant, Node node, String rate, String type, String username) {
         this.AccountId = AccountId;
         this.CardId = cardId;
         this.accountType = accountType;
@@ -51,6 +53,7 @@ public class Destination implements Serializable {
         this.description = description;
         this.fee = fee;
         this.merchant = merchant;
+        this.node = node;
         this.rate = rate;
         this.type = type;
         this.username = username;
@@ -154,6 +157,16 @@ public class Destination implements Serializable {
 
     public Merchant getMerchant() {
         return merchant;
+    }
+
+    /**
+     * Gets the node from the destination of the transaction.
+     *
+     * @return the node from the destination of the transaction.
+     */
+
+    public Node getNode() {
+        return node;
     }
 
     /**

--- a/src/app/src/main/java/com/uphold/uphold_android_sdk/model/transaction/Node.java
+++ b/src/app/src/main/java/com/uphold/uphold_android_sdk/model/transaction/Node.java
@@ -1,0 +1,59 @@
+package com.uphold.uphold_android_sdk.model.transaction;
+
+import java.io.Serializable;
+
+/**
+ * Node model.
+ */
+
+public class Node implements Serializable {
+
+    private final String brand;
+    private final String id;
+    private final String type;
+
+    /**
+     * Constructor.
+     *
+     * @param brand The brand of the node.
+     * @param id The id of the node.
+     * @param type The type of the node.
+     */
+
+    public Node(String brand, String id, String type) {
+        this.brand = brand;
+        this.id = id;
+        this.type = type;
+    }
+
+    /**
+     * Gets the brand of the node.
+     *
+     * @return the brand of the node.
+     */
+
+    public String getBrand() {
+        return brand;
+    }
+
+    /**
+     * Gets the id of the node.
+     *
+     * @return the id of the node.
+     */
+
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Gets the type of the node.
+     *
+     * @return the type of the node.
+     */
+
+    public String getType() {
+        return type;
+    }
+
+}

--- a/src/app/src/main/java/com/uphold/uphold_android_sdk/model/transaction/Origin.java
+++ b/src/app/src/main/java/com/uphold/uphold_android_sdk/model/transaction/Origin.java
@@ -19,6 +19,7 @@ public class Origin implements Serializable {
     private final String description;
     private final String fee;
     private final Merchant merchant;
+    private final Node node;
     private final String rate;
     private final List<Source> sources;
     private final String type;
@@ -37,13 +38,14 @@ public class Origin implements Serializable {
      * @param description The description from the origin of the transaction.
      * @param fee The fee from the origin of the transaction.
      * @param merchant The merchant from the origin of the transaction.
+     * @param node The node from the origin of the transaction.
      * @param rate The rate from the origin of the transaction.
      * @param sources The sources from the origin of the transaction.
      * @param type The type from the origin of the transaction.
      * @param username The username from the origin of the transaction.
      */
 
-    public Origin(String AccountId, String cardId, String accountType, String amount, String base, String commission, String currency, String description, String fee, Merchant merchant, String rate, List<Source> sources, String type, String username) {
+    public Origin(String AccountId, String cardId, String accountType, String amount, String base, String commission, String currency, String description, String fee, Merchant merchant, Node node, String rate, List<Source> sources, String type, String username) {
         this.AccountId = AccountId;
         this.CardId = cardId;
         this.accountType = accountType;
@@ -54,6 +56,7 @@ public class Origin implements Serializable {
         this.description = description;
         this.fee = fee;
         this.merchant = merchant;
+        this.node = node;
         this.rate = rate;
         this.sources = sources;
         this.type = type;
@@ -158,6 +161,16 @@ public class Origin implements Serializable {
 
     public Merchant getMerchant() {
         return merchant;
+    }
+
+    /**
+     * Gets the node from the origin of the transaction.
+     *
+     * @return the node from the origin of the transaction.
+     */
+
+    public Node getNode() {
+        return node;
     }
 
     /**

--- a/src/app/src/test/java/com/uphold/uphold_android_sdk/test/unit/model/TransactionTest.java
+++ b/src/app/src/test/java/com/uphold/uphold_android_sdk/test/unit/model/TransactionTest.java
@@ -5,6 +5,7 @@ import com.uphold.uphold_android_sdk.model.transaction.Denomination;
 import com.uphold.uphold_android_sdk.model.transaction.Destination;
 import com.uphold.uphold_android_sdk.model.transaction.Fee;
 import com.uphold.uphold_android_sdk.model.transaction.Merchant;
+import com.uphold.uphold_android_sdk.model.transaction.Node;
 import com.uphold.uphold_android_sdk.model.transaction.Normalized;
 import com.uphold.uphold_android_sdk.model.transaction.Origin;
 import com.uphold.uphold_android_sdk.model.transaction.Parameters;
@@ -31,13 +32,15 @@ public class TransactionTest {
     public void shouldBeSerializable() {
         Denomination denomination = new Denomination("foo", "bar", "fuz", "buz");
         Merchant destinationMerchant = new Merchant("foo", "bar", "biz", "buz", "foobar");
-        Destination destination = new Destination("fizbiz", "foobar", "biz", "foobiz", "foobuz", "fizbuz", "fizbiz", "foo", "bar", destinationMerchant, "fiz", "biz", "buz");
+        Node destinationNode = new Node("foo", "bar", "boz");
+        Destination destination = new Destination("fizbiz", "foobar", "biz", "foobiz", "foobuz", "fizbuz", "fizbiz", "foo", "bar", destinationMerchant, destinationNode, "fiz", "biz", "buz");
         Fee fee = new Fee("foo", "bar", "fuz", "buz", "biz");
         List<Fee> fees = new ArrayList<>();
         List<Normalized> normalizeds = new ArrayList<>();
         List<Source> sources = new ArrayList<>();
         Merchant originMerchant = new Merchant("fuz", "biz", "boz", "baz", "foobiz");
-        Origin origin = new Origin("biz", "foo", "fiz", "bar", "foobar", "foobiz", "fiz", "biz", "fuzbuz", originMerchant, "fuz", sources, "buz", "FOOBAR");
+        Node originNode = new Node("fiz", "bor", "baz");
+        Origin origin = new Origin("biz", "foo", "fiz", "bar", "foobar", "foobiz", "fiz", "biz", "fuzbuz", originMerchant, originNode, "fuz", sources, "buz", "FOOBAR");
         Parameters parameters = new Parameters("foobar", "foobiz", "foobuz", "fizbiz", "fuz", "fiz", 1, "foo", "bar");
         Normalized normalized = new Normalized("foo", "bar", "fiz", "biz", "fixbiz");
         Source source = new Source("FUZBUZ", "FIZBIZ");
@@ -69,6 +72,9 @@ public class TransactionTest {
         Assert.assertEquals(transaction.getDestination().getMerchant().getName(), deserializedTransaction.getDestination().getMerchant().getName());
         Assert.assertEquals(transaction.getDestination().getMerchant().getState(), deserializedTransaction.getDestination().getMerchant().getState());
         Assert.assertEquals(transaction.getDestination().getMerchant().getZipCode(), deserializedTransaction.getDestination().getMerchant().getZipCode());
+        Assert.assertEquals(transaction.getDestination().getNode().getBrand(), deserializedTransaction.getDestination().getNode().getBrand());
+        Assert.assertEquals(transaction.getDestination().getNode().getId(), deserializedTransaction.getDestination().getNode().getId());
+        Assert.assertEquals(transaction.getDestination().getNode().getType(), deserializedTransaction.getDestination().getNode().getType());
         Assert.assertEquals(transaction.getDestination().getRate(), deserializedTransaction.getDestination().getRate());
         Assert.assertEquals(transaction.getDestination().getType(), deserializedTransaction.getDestination().getType());
         Assert.assertEquals(transaction.getDestination().getUsername(), deserializedTransaction.getDestination().getUsername());
@@ -100,6 +106,9 @@ public class TransactionTest {
         Assert.assertEquals(transaction.getOrigin().getMerchant().getName(), deserializedTransaction.getOrigin().getMerchant().getName());
         Assert.assertEquals(transaction.getOrigin().getMerchant().getState(), deserializedTransaction.getOrigin().getMerchant().getState());
         Assert.assertEquals(transaction.getOrigin().getMerchant().getZipCode(), deserializedTransaction.getOrigin().getMerchant().getZipCode());
+        Assert.assertEquals(transaction.getOrigin().getNode().getBrand(), deserializedTransaction.getOrigin().getNode().getBrand());
+        Assert.assertEquals(transaction.getOrigin().getNode().getId(), deserializedTransaction.getOrigin().getNode().getId());
+        Assert.assertEquals(transaction.getOrigin().getNode().getType(), deserializedTransaction.getOrigin().getNode().getType());
         Assert.assertEquals(transaction.getOrigin().getRate(), deserializedTransaction.getOrigin().getRate());
         Assert.assertEquals(transaction.getOrigin().getSources().size(), deserializedTransaction.getOrigin().getSources().size());
         Assert.assertEquals(transaction.getOrigin().getSources().get(0).getAmount(), deserializedTransaction.getOrigin().getSources().get(0).getAmount());


### PR DESCRIPTION
This PR adds the `Node` model to the `Origin`/`Destination` models of a transaction.