### PR TITLE
Add support for transaction commit request beneficiary

### DIFF
--- a/src/app/src/androidTest/java/com/uphold/uphold_android_sdk/test/integration/service/UserCardServiceTest.java
+++ b/src/app/src/androidTest/java/com/uphold/uphold_android_sdk/test/integration/service/UserCardServiceTest.java
@@ -74,7 +74,7 @@ public class UserCardServiceTest {
                 UserCardService userCardService = adapter.getRestAdapter().create(UserCardService.class);
                 RetrofitPromise<Transaction> promise = new RetrofitPromise<>();
 
-                userCardService.confirmTransaction("foo", "bar", new TransactionCommitRequest("message", "securityCode"), "otp", promise);
+                userCardService.confirmTransaction("foo", "bar", new TransactionCommitRequest("message"), "otp", promise);
 
                 return promise;
             }

--- a/src/app/src/main/java/com/uphold/uphold_android_sdk/model/Transaction.java
+++ b/src/app/src/main/java/com/uphold/uphold_android_sdk/model/Transaction.java
@@ -207,7 +207,7 @@ public class Transaction extends BaseModel implements Serializable {
         }
 
         if (transactionCommitRequest == null) {
-            transactionCommitRequest = new TransactionCommitRequest(null);
+            transactionCommitRequest = new TransactionCommitRequest(null, null);
         }
 
         userCardService.confirmTransaction(getCardIdPath(), this.getId(), transactionCommitRequest, otp, promise);

--- a/src/app/src/main/java/com/uphold/uphold_android_sdk/model/transaction/Beneficiary.java
+++ b/src/app/src/main/java/com/uphold/uphold_android_sdk/model/transaction/Beneficiary.java
@@ -1,0 +1,59 @@
+package com.uphold.uphold_android_sdk.model.transaction;
+
+import java.io.Serializable;
+
+/**
+ * Beneficiary model.
+ */
+
+public class Beneficiary implements Serializable {
+
+    private final BeneficiaryAddress address;
+    private final String name;
+    private final String relationship;
+
+    /**
+     * Constructor.
+     *
+     * @param address The address.
+     * @param name The name.
+     * @param relationship The relationship.
+     */
+
+    public Beneficiary(BeneficiaryAddress address, String name, String relationship) {
+        this.address = address;
+        this.name = name;
+        this.relationship = relationship;
+    }
+
+    /**
+     * Gets the address.
+     *
+     * @return return the address.
+     */
+
+    public BeneficiaryAddress getAddress() {
+        return address;
+    }
+
+    /**
+     * Gets the name.
+     *
+     * @return return the name.
+     */
+
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Gets the relationship.
+     *
+     * @return return the relationship.
+     */
+
+    public String getRelationship() {
+        return relationship;
+    }
+
+}

--- a/src/app/src/main/java/com/uphold/uphold_android_sdk/model/transaction/BeneficiaryAddress.java
+++ b/src/app/src/main/java/com/uphold/uphold_android_sdk/model/transaction/BeneficiaryAddress.java
@@ -1,0 +1,98 @@
+package com.uphold.uphold_android_sdk.model.transaction;
+
+import java.io.Serializable;
+
+/**
+ * Beneficiary address model.
+ */
+
+public class BeneficiaryAddress implements Serializable {
+
+    private final String city;
+    private final String country;
+    private final String line1;
+    private final String line2;
+    private final String state;
+    private final String zipCode;
+
+    /**
+     * Constructor.
+     *
+     * @param city The city.
+     * @param country The country.
+     * @param line1 The line 1.
+     * @param line2 The line 2.
+     * @param state The state.
+     * @param zipCode The zip code.
+     */
+
+    public BeneficiaryAddress(String city, String country, String line1, String line2, String state, String zipCode) {
+        this.city = city;
+        this.country = country;
+        this.line1 = line1;
+        this.line2 = line2;
+        this.state = state;
+        this.zipCode = zipCode;
+    }
+
+    /**
+     * Gets the city.
+     *
+     * @return the city.
+     */
+
+    public String getCity() {
+        return city;
+    }
+
+    /**
+     * Gets the country.
+     *
+     * @return the country.
+     */
+
+    public String getCountry() {
+        return country;
+    }
+
+    /**
+     * Gets the line 1.
+     *
+     * @return the line 1.
+     */
+
+    public String getLine1() {
+        return line1;
+    }
+
+    /**
+     * Gets the line 2.
+     *
+     * @return the line 2.
+     */
+
+    public String getLine2() {
+        return line2;
+    }
+
+    /**
+     * Gets the state.
+     *
+     * @return the state.
+     */
+
+    public String getState() {
+        return state;
+    }
+
+    /**
+     * Gets the zip code.
+     *
+     * @return the zip code.
+     */
+
+    public String getZipCode() {
+        return zipCode;
+    }
+
+}

--- a/src/app/src/main/java/com/uphold/uphold_android_sdk/model/transaction/TransactionCommitRequest.java
+++ b/src/app/src/main/java/com/uphold/uphold_android_sdk/model/transaction/TransactionCommitRequest.java
@@ -8,8 +8,19 @@ import java.io.Serializable;
 
 public class TransactionCommitRequest implements Serializable {
 
-    String message;
-    String securityCode;
+    private final Beneficiary beneficiary;
+    private final String message;
+
+    /**
+     * Constructor.
+     *
+     * @param beneficiary The transaction beneficiary.
+     */
+
+    public TransactionCommitRequest(Beneficiary beneficiary) {
+        this.beneficiary = beneficiary;
+        this.message = null;
+    }
 
     /**
      * Constructor.
@@ -18,39 +29,40 @@ public class TransactionCommitRequest implements Serializable {
      */
 
     public TransactionCommitRequest(String message) {
+        this.beneficiary = null;
         this.message = message;
     }
 
     /**
      * Constructor.
      *
+     * @param beneficiary The transaction beneficiary.
      * @param message The transaction message.
-     * @param securityCode The transaction security code.
      */
 
-    public TransactionCommitRequest(String message, String securityCode) {
+    public TransactionCommitRequest(Beneficiary beneficiary, String message) {
+        this.beneficiary = beneficiary;
         this.message = message;
-        this.securityCode = securityCode;
+    }
+
+    /**
+     * Gets the transaction beneficiary.
+     *
+     * @return the transaction beneficiary.
+     */
+
+    public Beneficiary getBeneficiary() {
+        return beneficiary;
     }
 
     /**
      * Gets the transaction request message.
      *
-     * @return the transaction request message
+     * @return the transaction request message.
      */
 
     public String getMessage() {
         return message;
-    }
-
-    /**
-     * Gets the transaction security code.
-     *
-     * @return the transaction security code
-     */
-
-    public String getSecurityCode() {
-        return securityCode;
     }
 
 }

--- a/src/app/src/test/java/com/uphold/uphold_android_sdk/test/unit/model/transaction/TransactionCommitRequestTest.java
+++ b/src/app/src/test/java/com/uphold/uphold_android_sdk/test/unit/model/transaction/TransactionCommitRequestTest.java
@@ -1,5 +1,7 @@
 package com.uphold.uphold_android_sdk.test.unit.model.transaction;
 
+import com.uphold.uphold_android_sdk.model.transaction.Beneficiary;
+import com.uphold.uphold_android_sdk.model.transaction.BeneficiaryAddress;
 import com.uphold.uphold_android_sdk.model.transaction.TransactionCommitRequest;
 
 import junit.framework.Assert;
@@ -26,13 +28,40 @@ public class TransactionCommitRequestTest {
     }
 
     @Test
-    public void shouldBeSerializableTransactionCommitRequestWithSecurityCode() {
-        TransactionCommitRequest transactionCommitRequest = new TransactionCommitRequest("foobar", "foo");
+    public void shouldBeSerializableTransactionCommitRequestWithBeneficiary() {
+        BeneficiaryAddress address = new BeneficiaryAddress("faz", "fez", "fiz", "foz", "fuz", "foobiz");
+        Beneficiary beneficiary = new Beneficiary(address, "buz", "fez");
+        TransactionCommitRequest transactionCommitRequest = new TransactionCommitRequest(beneficiary);
+        byte[] serializedTransactionCommitRequestTest = SerializationUtils.serialize(transactionCommitRequest);
+        TransactionCommitRequest deserializedTransactionCommitRequestTest = SerializationUtils.deserialize(serializedTransactionCommitRequestTest);
+
+        Assert.assertEquals(transactionCommitRequest.getBeneficiary().getAddress().getCity(), deserializedTransactionCommitRequestTest.getBeneficiary().getAddress().getCity());
+        Assert.assertEquals(transactionCommitRequest.getBeneficiary().getAddress().getCountry(), deserializedTransactionCommitRequestTest.getBeneficiary().getAddress().getCountry());
+        Assert.assertEquals(transactionCommitRequest.getBeneficiary().getAddress().getLine1(), deserializedTransactionCommitRequestTest.getBeneficiary().getAddress().getLine1());
+        Assert.assertEquals(transactionCommitRequest.getBeneficiary().getAddress().getLine2(), deserializedTransactionCommitRequestTest.getBeneficiary().getAddress().getLine2());
+        Assert.assertEquals(transactionCommitRequest.getBeneficiary().getAddress().getState(), deserializedTransactionCommitRequestTest.getBeneficiary().getAddress().getState());
+        Assert.assertEquals(transactionCommitRequest.getBeneficiary().getAddress().getZipCode(), deserializedTransactionCommitRequestTest.getBeneficiary().getAddress().getZipCode());
+        Assert.assertEquals(transactionCommitRequest.getBeneficiary().getName(), deserializedTransactionCommitRequestTest.getBeneficiary().getName());
+        Assert.assertEquals(transactionCommitRequest.getBeneficiary().getRelationship(), deserializedTransactionCommitRequestTest.getBeneficiary().getRelationship());
+    }
+
+    @Test
+    public void shouldBeSerializableTransactionCommitRequestWithBeneficiaryAndMessage() {
+        BeneficiaryAddress address = new BeneficiaryAddress("faz", "fez", "fiz", "foz", "fuz", "foobiz");
+        Beneficiary beneficiary = new Beneficiary(address, "buz", "fez");
+        TransactionCommitRequest transactionCommitRequest = new TransactionCommitRequest(beneficiary, "foo");
         byte[] serializedTransactionCommitRequestTest = SerializationUtils.serialize(transactionCommitRequest);
         TransactionCommitRequest deserializedTransactionCommitRequestTest = SerializationUtils.deserialize(serializedTransactionCommitRequestTest);
 
         Assert.assertEquals(transactionCommitRequest.getMessage(), deserializedTransactionCommitRequestTest.getMessage());
-        Assert.assertEquals(transactionCommitRequest.getSecurityCode(), deserializedTransactionCommitRequestTest.getSecurityCode());
+        Assert.assertEquals(transactionCommitRequest.getBeneficiary().getAddress().getCity(), deserializedTransactionCommitRequestTest.getBeneficiary().getAddress().getCity());
+        Assert.assertEquals(transactionCommitRequest.getBeneficiary().getAddress().getCountry(), deserializedTransactionCommitRequestTest.getBeneficiary().getAddress().getCountry());
+        Assert.assertEquals(transactionCommitRequest.getBeneficiary().getAddress().getLine1(), deserializedTransactionCommitRequestTest.getBeneficiary().getAddress().getLine1());
+        Assert.assertEquals(transactionCommitRequest.getBeneficiary().getAddress().getLine2(), deserializedTransactionCommitRequestTest.getBeneficiary().getAddress().getLine2());
+        Assert.assertEquals(transactionCommitRequest.getBeneficiary().getAddress().getState(), deserializedTransactionCommitRequestTest.getBeneficiary().getAddress().getState());
+        Assert.assertEquals(transactionCommitRequest.getBeneficiary().getAddress().getZipCode(), deserializedTransactionCommitRequestTest.getBeneficiary().getAddress().getZipCode());
+        Assert.assertEquals(transactionCommitRequest.getBeneficiary().getName(), deserializedTransactionCommitRequestTest.getBeneficiary().getName());
+        Assert.assertEquals(transactionCommitRequest.getBeneficiary().getRelationship(), deserializedTransactionCommitRequestTest.getBeneficiary().getRelationship());
     }
 
 }


### PR DESCRIPTION
This PR adds support for a `beneficiary` field in the `TransactionCommitRequest` model.