### PR TITLE
Add support for transaction destination address

### DIFF
--- a/src/app/src/androidTest/java/com/uphold/uphold_android_sdk/test/util/Fixtures.java
+++ b/src/app/src/androidTest/java/com/uphold/uphold_android_sdk/test/util/Fixtures.java
@@ -162,6 +162,7 @@ public class Fixtures {
             put("denominationRate", faker.numerify("123456789"));
             put("destinationAccountId", faker.numerify("123456789"));
             put("destinationAccountType", faker.lorem().fixedString(7));
+            put("destinationAddress", faker.lorem().fixedString(20));
             put("destinationAmount", faker.numerify("123456789"));
             put("destinationBase", faker.numerify("123456789"));
             put("destinationCardId", faker.lorem().fixedString(24));
@@ -238,7 +239,7 @@ public class Fixtures {
         Merchant destinationMerchant = new Merchant(fakerFields.get("destinationMerchantCity"), fakerFields.get("destinationMerchantCountry"), fakerFields.get("destinationMerchantName"), fakerFields.get("destinationMerchantState"),
             fakerFields.get("destinationMerchantZipCode"));
         Node destinationNode = new Node(fakerFields.get("destinationNodeBrand"), fakerFields.get("destinationNodeId"), fakerFields.get("destinationNodeType"));
-        Destination destination = new Destination(fakerFields.get("destinationAccountId"), fakerFields.get("destinationCardId"), fakerFields.get("destinationAccountType"), fakerFields.get("destinationAmount"), fakerFields.get("destinationBase"),
+        Destination destination = new Destination(fakerFields.get("destinationAccountId"), fakerFields.get("destinationCardId"), fakerFields.get("destinationAccountType"), fakerFields.get("destinationAddress"), fakerFields.get("destinationAmount"), fakerFields.get("destinationBase"),
             fakerFields.get("destinationCommission"), fakerFields.get("destinationCurrency"), fakerFields.get("destinationDescription"), fakerFields.get("destinationFee"), destinationMerchant, destinationNode, fakerFields.get("destinationRate"),
             fakerFields.get("destinationType"), fakerFields.get("destinationUsername"));
         ArrayList<Fee> fees = new ArrayList<Fee>() {{

--- a/src/app/src/main/java/com/uphold/uphold_android_sdk/model/transaction/Destination.java
+++ b/src/app/src/main/java/com/uphold/uphold_android_sdk/model/transaction/Destination.java
@@ -11,6 +11,7 @@ public class Destination implements Serializable {
     private final String AccountId;
     private final String CardId;
     private final String accountType;
+    private final String address;
     private final String amount;
     private final String base;
     private final String commission;
@@ -29,6 +30,7 @@ public class Destination implements Serializable {
      * @param AccountId The id of the account from the destination of the transaction.
      * @param cardId The card id of the card from the destination of the transaction.
      * @param accountType The type of the account from the destination of the transaction.
+     * @param address The address from the destination of the transaction.
      * @param amount The amount from the destination of the transaction.
      * @param base The base from the destination of the transaction.
      * @param commission The commission from the destination of the transaction.
@@ -42,10 +44,11 @@ public class Destination implements Serializable {
      * @param username The username from the destination of the transaction.
      */
 
-    public Destination(String AccountId, String cardId, String accountType, String amount, String base, String commission, String currency, String description, String fee, Merchant merchant, Node node, String rate, String type, String username) {
+    public Destination(String AccountId, String cardId, String accountType, String address, String amount, String base, String commission, String currency, String description, String fee, Merchant merchant, Node node, String rate, String type, String username) {
         this.AccountId = AccountId;
         this.CardId = cardId;
         this.accountType = accountType;
+        this.address = address;
         this.amount = amount;
         this.base = base;
         this.commission = commission;
@@ -87,6 +90,16 @@ public class Destination implements Serializable {
 
     public String getAccountType() {
         return accountType;
+    }
+
+    /**
+     * Gets the address from the destination of the transaction.
+     *
+     * @return the address from the destination of the transaction.
+     */
+
+    public String getAddress() {
+        return address;
     }
 
     /**

--- a/src/app/src/test/java/com/uphold/uphold_android_sdk/test/unit/model/TransactionTest.java
+++ b/src/app/src/test/java/com/uphold/uphold_android_sdk/test/unit/model/TransactionTest.java
@@ -33,7 +33,7 @@ public class TransactionTest {
         Denomination denomination = new Denomination("foo", "bar", "fuz", "buz");
         Merchant destinationMerchant = new Merchant("foo", "bar", "biz", "buz", "foobar");
         Node destinationNode = new Node("foo", "bar", "boz");
-        Destination destination = new Destination("fizbiz", "foobar", "biz", "foobiz", "foobuz", "fizbuz", "fizbiz", "foo", "bar", destinationMerchant, destinationNode, "fiz", "biz", "buz");
+        Destination destination = new Destination("fizbiz", "foobar", "biz", "fizbuz", "foobiz", "foobuz", "fizbuz", "fizbiz", "foo", "bar", destinationMerchant, destinationNode, "fiz", "biz", "buz");
         Fee fee = new Fee("foo", "bar", "fuz", "buz", "biz");
         List<Fee> fees = new ArrayList<>();
         List<Normalized> normalizeds = new ArrayList<>();
@@ -60,6 +60,7 @@ public class TransactionTest {
         Assert.assertEquals(transaction.getDenomination().getRate(), deserializedTransaction.getDenomination().getRate());
         Assert.assertEquals(transaction.getDestination().getAccountId(), deserializedTransaction.getDestination().getAccountId());
         Assert.assertEquals(transaction.getDestination().getAccountType(), deserializedTransaction.getDestination().getAccountType());
+        Assert.assertEquals(transaction.getDestination().getAddress(), deserializedTransaction.getDestination().getAddress());
         Assert.assertEquals(transaction.getDestination().getAmount(), deserializedTransaction.getDestination().getAmount());
         Assert.assertEquals(transaction.getDestination().getBase(), deserializedTransaction.getDestination().getBase() );
         Assert.assertEquals(transaction.getDestination().getCardId(), deserializedTransaction.getDestination().getCardId());


### PR DESCRIPTION
This PR adds support for the `address` field in the `Destination` model.