### PR TITLE
Bump `compileSdkVersion`, `buildToolsVersion` and `targetSdkVersion`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,12 @@ env:
 
 android:
   components:
-    - android-22
     - android-21
-    - android-26
-    - build-tools-26.0.2
-    - sys-img-armeabi-v7a-android-22
+    - android-22
+    - android-28
+    - build-tools-28.0.2
     - sys-img-armeabi-v7a-android-21
+    - sys-img-armeabi-v7a-android-22
 
 cache:
   directories:

--- a/src/app/build.gradle
+++ b/src/app/build.gradle
@@ -4,8 +4,8 @@ apply plugin: 'com.github.dcendents.android-maven'
 group='com.github.uphold'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion '26.0.2'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.2'
     publishNonDefault true
     testBuildType "debug"
 
@@ -18,7 +18,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 20
         versionName "0.16.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -53,6 +53,9 @@ android {
             buildConfigField 'String', 'AUTHORIZATION_SERVER_URL', '"https://sandbox.uphold.com"'
         }
     }
+    
+    useLibrary 'android.test.base'
+    useLibrary 'android.test.mock'
 }
 
 if(android.productFlavors.size() > 0) {

--- a/src/app/src/main/java/com/uphold/uphold_android_sdk/client/session/SessionManager.java
+++ b/src/app/src/main/java/com/uphold/uphold_android_sdk/client/session/SessionManager.java
@@ -75,7 +75,10 @@ public enum SessionManager {
 
         if (com.uphold.uphold_android_sdk.client.UpholdClient.getApplicationContext() != null) {
             initSharedPreferences();
-            sharedPreferences.edit().remove(CACHED_ACCESS_TOKEN_KEY).apply();
+
+            if (sharedPreferences != null) {
+                sharedPreferences.edit().remove(CACHED_ACCESS_TOKEN_KEY).apply();
+            }
         }
     }
 

--- a/src/app/src/test/java/com/uphold/uphold_android_sdk/test/unit/client/UpholdClientTest.java
+++ b/src/app/src/test/java/com/uphold/uphold_android_sdk/test/unit/client/UpholdClientTest.java
@@ -1,12 +1,11 @@
 package com.uphold.uphold_android_sdk.test.unit.client;
 
+import android.content.Context;
 import android.net.Uri;
-import android.test.mock.MockContext;
 import android.text.TextUtils;
 
 import com.uphold.uphold_android_sdk.BuildConfig;
 import com.uphold.uphold_android_sdk.client.UpholdClient;
-import com.uphold.uphold_android_sdk.test.unit.util.MockSharedPreferencesContext;
 import com.uphold.uphold_android_sdk.util.Header;
 
 import org.junit.Test;
@@ -29,7 +28,7 @@ public class UpholdClientTest {
 
     @Test
     public void beginAuthorizationShouldCallUriParse() throws Exception {
-        UpholdClient.initialize(new MockSharedPreferencesContext());
+        UpholdClient.initialize(PowerMockito.mock(Context.class));
 
         UpholdClient upholdClient = new UpholdClient();
         ArrayList<String> scopes = new ArrayList<String>() {{
@@ -40,7 +39,7 @@ public class UpholdClientTest {
         PowerMockito.when(TextUtils.join(" ", scopes)).thenReturn("foo");
 
         PowerMockito.mockStatic(Uri.class);
-        upholdClient.beginAuthorization(new MockContext(), "foo", scopes, "bar");
+        upholdClient.beginAuthorization(PowerMockito.mock(Context.class), "foo", scopes, "bar");
 
         PowerMockito.verifyStatic();
         Uri.parse(String.format("%s/authorize/foo?scope=foo&state=bar", BuildConfig.AUTHORIZATION_SERVER_URL));


### PR DESCRIPTION
This PR bumps the `compileSdkVersion` and `targetSdkVersion` to version `28` and the `buildToolsVersion` to version `28.0.2`.